### PR TITLE
fix/csharp: change code format

### DIFF
--- a/resources/csharp/Utils.cs.template
+++ b/resources/csharp/Utils.cs.template
@@ -3,124 +3,155 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
-namespace @Namespace {
-  public class FfiException : Exception {
-    public readonly int ErrorCode;
-
-    public FfiException(int code, string description)
-      : base($"Error Code: {code}. Description: {description}")
+namespace @Namespace
+{
+    public class FfiException : Exception
     {
-      ErrorCode = code;
-    }
-  }
+        public readonly int ErrorCode;
 
-  public struct FfiResult {
-    public int ErrorCode;
-    [MarshalAs(UnmanagedType.LPStr)]
-    public string Description;
-
-    public FfiException ToException() {
-      return new FfiException(ErrorCode, Description);
-    }
-  }
-
-  public class @Class {
-    public static IntPtr ToHandlePtr<T>(T obj) {
-        return GCHandle.ToIntPtr(GCHandle.Alloc(obj));
+        public FfiException(int code, string description)
+            : base($"Error Code: {code}. Description: {description}")
+        {
+            ErrorCode = code;
+        }
     }
 
-    public static T FromHandlePtr<T>(IntPtr ptr, bool free = true) {
-      var handle = GCHandle.FromIntPtr(ptr);
-      var result = (T) handle.Target;
+    public struct FfiResult
+    {
+        public int ErrorCode;
+        [MarshalAs(UnmanagedType.LPStr)]
+        public string Description;
 
-      if (free) handle.Free();
-
-      return result;
+        public FfiException ToException()
+        {
+            return new FfiException(ErrorCode, Description);
+        }
     }
 
-    public static (Task<T>, IntPtr) PrepareTask<T>() {
-      var tcs = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
-      var userData = ToHandlePtr(tcs);
+    public class @Class
+    {
+        private static void CompleteTask<T>(TaskCompletionSource<T> tcs, FfiResult result, Func<T> argFunc)
+        {
+            if (result.ErrorCode != 0)
+            {
+                tcs.SetException(result.ToException());
+            }
+            else
+            {
+                tcs.SetResult(argFunc());
+            }
+        }
 
-      return (tcs.Task, userData);
+        public static void CompleteTask<T>(IntPtr userData, FfiResult result, Func<T> argFunc)
+        {
+            var tcs = FromHandlePtr<TaskCompletionSource<T>>(userData);
+            CompleteTask(tcs, result, argFunc);
+        }
+
+        public static void CompleteTask(IntPtr userData, FfiResult result)
+        {
+            CompleteTask(userData, result, () => true);
+        }
+
+        public static IntPtr CopyFromByteList(List<byte> list)
+        {
+            if (list == null || list.Count == 0)
+            {
+                return IntPtr.Zero;
+            }
+
+            var array = list.ToArray();
+            var size = Marshal.SizeOf(array[0]) * array.Length;
+            var ptr = Marshal.AllocHGlobal(size);
+            Marshal.Copy(array, 0, ptr, array.Length);
+
+            return ptr;
+        }
+
+        public static IntPtr CopyFromObjectList<T>(List<T> list)
+        {
+            if (list == null || list.Count == 0)
+            {
+                return IntPtr.Zero;
+            }
+
+            var size = Marshal.SizeOf(list[0]) * list.Count;
+            var ptr = Marshal.AllocHGlobal(size);
+            for (var i = 0; i < list.Count; ++i)
+            {
+                Marshal.StructureToPtr(list[i], IntPtr.Add(ptr, Marshal.SizeOf<T>() * i), false);
+            }
+
+            return ptr;
+        }
+
+        public static byte[] CopyToByteArray(IntPtr ptr, int len)
+        {
+            var array = new byte[len];
+            if (len > 0)
+            {
+                Marshal.Copy(ptr, array, 0, len);
+            }
+
+            return array;
+        }
+
+        public static List<byte> CopyToByteList(IntPtr ptr, int len)
+        {
+            return new List<byte>(CopyToByteArray(ptr, len));
+        }
+
+        public static List<T> CopyToObjectList<T>(IntPtr ptr, int len)
+        {
+            var list = new List<T>(len);
+            for (var i = 0; i < len; ++i)
+            {
+                list.Add(Marshal.PtrToStructure<T>(IntPtr.Add(ptr, Marshal.SizeOf<T>() * i)));
+            }
+
+            return list;
+        }
+
+        public static void FreeList(ref IntPtr ptr, ref UIntPtr len)
+        {
+            if (ptr != IntPtr.Zero)
+            {
+                Marshal.FreeHGlobal(ptr);
+            }
+
+            ptr = IntPtr.Zero;
+            len = UIntPtr.Zero;
+        }
+
+        public static T FromHandlePtr<T>(IntPtr ptr, bool free = true)
+        {
+            var handle = GCHandle.FromIntPtr(ptr);
+            var result = (T)handle.Target;
+
+            if (free)
+            {
+                handle.Free();
+            }
+
+            return result;
+        }
+
+        public static (Task<T>, IntPtr) PrepareTask<T>()
+        {
+            var tcs = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var userData = ToHandlePtr(tcs);
+
+            return (tcs.Task, userData);
+        }
+
+        public static (Task, IntPtr) PrepareTask()
+        {
+            return PrepareTask<bool>();
+        }
+
+        public static IntPtr ToHandlePtr<T>(T obj)
+        {
+            return GCHandle.ToIntPtr(GCHandle.Alloc(obj));
+        }
     }
-
-    public static (Task, IntPtr) PrepareTask() {
-      return PrepareTask<bool>();
-    }
-
-    public static void CompleteTask<T>(TaskCompletionSource<T> tcs, FfiResult result, Func<T> argFunc) {
-      if (result.ErrorCode != 0) {
-        tcs.SetException(result.ToException());
-      } else {
-        tcs.SetResult(argFunc());
-      }
-    }
-
-    public static void CompleteTask<T>(IntPtr userData, FfiResult result, Func<T> argFunc) {
-      var tcs = FromHandlePtr<TaskCompletionSource<T>>(userData);
-      CompleteTask(tcs, result, argFunc);
-    }
-
-    public static void CompleteTask(IntPtr userData, FfiResult result) {
-      CompleteTask(userData, result, () => true);
-    }
-
-    public static byte[] CopyToByteArray(IntPtr ptr, int len) {
-      var array = new byte[len];
-      if (len > 0) {
-        Marshal.Copy(ptr, array, 0, len);
-      }
-      return array;
-    }
-
-    public static List<byte> CopyToByteList(IntPtr ptr, int len) {
-      return new List<byte>(CopyToByteArray(ptr, len));
-    }
-
-    public static List<T> CopyToObjectList<T>(IntPtr ptr, int len) {
-      var list = new List<T>(len);
-      for (var i = 0; i < len; ++i) {
-        list.Add(Marshal.PtrToStructure<T>(IntPtr.Add(ptr, Marshal.SizeOf<T>() * i)));
-      }
-
-      return list;
-    }
-
-    public static IntPtr CopyFromByteList(List<byte> list) {
-      if (list == null || list.Count == 0) {
-        return IntPtr.Zero;
-      }
-
-      var array = list.ToArray();
-      var size = Marshal.SizeOf(array[0]) * array.Length;
-      var ptr  = Marshal.AllocHGlobal(size);
-      Marshal.Copy(array, 0, ptr, array.Length);
-
-      return ptr;
-    }
-
-    public static IntPtr CopyFromObjectList<T>(List<T> list) {
-      if (list == null || list.Count == 0) {
-        return IntPtr.Zero;
-      }
-
-      var size = Marshal.SizeOf(list[0]) * list.Count;
-      var ptr  = Marshal.AllocHGlobal(size);
-      for (var i = 0; i < list.Count; ++i) {
-          Marshal.StructureToPtr(list[i], IntPtr.Add(ptr, Marshal.SizeOf<T>() * i), false);
-      }
-
-      return ptr;
-    }
-
-    public static void FreeList(ref IntPtr ptr, ref UIntPtr len) {
-      if (ptr != IntPtr.Zero) {
-          Marshal.FreeHGlobal(ptr);
-      }
-
-      ptr = IntPtr.Zero;
-      len = UIntPtr.Zero;
-    }
-  }
 }

--- a/src/csharp/emit.rs
+++ b/src/csharp/emit.rs
@@ -55,7 +55,7 @@ pub fn emit_wrapper_function(
     let return_name = "ret";
 
     emit_wrapper_function_decl(writer, context, "public", name, fun);
-    emitln!(writer, " {{");
+    emitln!(writer, "\n{{");
     writer.indent();
 
     // Convert wrapper structs to native structs.
@@ -101,7 +101,7 @@ pub fn emit_wrapper_function(
             match *ty {
                 Type::Array(_, ArraySize::Dynamic) => emit!(
                     writer,
-                    "{0}?.ToArray(), ({1}) ({0}?.Count ?? 0)",
+                    "{0}?.ToArray(), ({1})({0}?.Count ?? 0)",
                     name,
                     LEN_TYPE
                 ),
@@ -173,7 +173,7 @@ pub fn emit_callback_wrapper(writer: &mut IndentedWriter, context: &Context, cal
     emit_callback_wrapper_name(writer, callback);
     emit!(writer, "(");
     emit_callback_params(writer, context, &callback.inputs);
-    emitln!(writer, ") {{");
+    emitln!(writer, ")\n{{");
     writer.indent();
 
     emit!(writer, "{}.CompleteTask(", &context.utils_section.class);
@@ -227,7 +227,7 @@ pub fn emit_const(writer: &mut IndentedWriter, context: &Context, name: &str, it
 
 pub fn emit_enum(writer: &mut IndentedWriter, context: &Context, name: &str, item: &Enum) {
     emitln!(writer, "[PublicAPI]");
-    emitln!(writer, "public enum {} {{", name);
+    emitln!(writer, "public enum {}\n{{", name);
     writer.indent();
 
     for variant in &item.variants {
@@ -251,7 +251,7 @@ pub fn emit_normal_struct(
     item: &Struct,
 ) {
     emitln!(writer, "[PublicAPI]");
-    emitln!(writer, "public struct {} {{", name);
+    emitln!(writer, "public struct {}\n{{", name);
     writer.indent();
 
     for field in &item.fields {
@@ -269,7 +269,7 @@ pub fn emit_native_struct(
     name: &str,
     item: &Struct,
 ) {
-    emitln!(writer, "internal struct {}Native {{", name);
+    emitln!(writer, "internal struct {}Native\n{{", name);
     writer.indent();
 
     for field in &item.fields {
@@ -279,7 +279,7 @@ pub fn emit_native_struct(
 
     // Emit `Free` method.
     emitln!(writer, "");
-    emitln!(writer, "internal void Free() {{");
+    emitln!(writer, "internal void Free()\n{{");
     writer.indent();
 
     for field in &item.fields {
@@ -311,7 +311,7 @@ pub fn emit_wrapper_struct(
     item: &Struct,
 ) {
     emitln!(writer, "[PublicAPI]");
-    emitln!(writer, "public struct {} {{", name);
+    emitln!(writer, "public struct {}\n{{", name);
     writer.indent();
 
     for field in &item.fields {
@@ -321,7 +321,7 @@ pub fn emit_wrapper_struct(
     emitln!(writer, "");
 
     // Emit constructor.
-    emitln!(writer, "internal {0}({0}Native native) {{", name);
+    emitln!(writer, "internal {0}({0}Native native)\n{{", name);
     writer.indent();
 
     for field in &item.fields {
@@ -331,7 +331,7 @@ pub fn emit_wrapper_struct(
 
         if let Type::Array(ref ty, ArraySize::Dynamic) = field.ty {
             emit_copy_to_utility_name(writer, context, ty, "List");
-            emitln!(writer, "(native.{0}Ptr, (int) native.{0}Len);", name);
+            emitln!(writer, "(native.{0}Ptr, (int)native.{0}Len);", name);
         } else if context.is_native_type(&field.ty) {
             emit!(writer, "new ");
             emit_type(writer, context, &field.ty, Mode::WrapperStruct);
@@ -345,10 +345,10 @@ pub fn emit_wrapper_struct(
     emitln!(writer, "}}\n");
 
     // Emit `ToNative` method.
-    emitln!(writer, "internal {}Native ToNative() {{", name);
+    emitln!(writer, "internal {}Native ToNative()\n{{", name);
     writer.indent();
 
-    emitln!(writer, "return new {}Native() {{", name);
+    emitln!(writer, "return new {}Native\n{{", name);
     writer.indent();
 
     for (index, field) in item.fields.iter().enumerate() {
@@ -358,7 +358,7 @@ pub fn emit_wrapper_struct(
             emit!(writer, "{}Ptr = ", name);
             emit_copy_from_utility_name(writer, context, ty);
             emitln!(writer, "({}),", name);
-            emit!(writer, "{0}Len = ({1}) ({0}?.Count ?? 0)", name, LEN_TYPE);
+            emit!(writer, "{0}Len = ({1})({0}?.Count ?? 0)", name, LEN_TYPE);
 
             if field.has_cap {
                 emitln!(writer, ",");
@@ -517,7 +517,7 @@ fn emit_struct_field(
         if field.has_cap {
             emitln!(
                 writer,
-                "// ReSharper disable once NotAccessedField.Compiler"
+                "\n// ReSharper disable once NotAccessedField.Compiler"
             );
             emitln!(writer, "public {} {}Cap;", LEN_TYPE, name);
         }
@@ -680,7 +680,7 @@ fn emit_array_marshal_as(
     match *size {
         ArraySize::Lit(value) => emit!(writer, ", SizeConst = {}", value),
         ArraySize::Const(ref name) => {
-            emit!(writer, ", SizeConst = (int) ");
+            emit!(writer, ", SizeConst = (int)");
             emit_const_use(writer, context, name);
         }
         ArraySize::Dynamic => {
@@ -842,7 +842,7 @@ fn emit_args(
             Type::User(ref type_name) if context.is_native_name(type_name) => {
                 emit!(writer, "new {}({})", type_name, name);
             }
-            Type::USize => emit!(writer, "(ulong) {}", name),
+            Type::USize => emit!(writer, "(ulong){}", name),
             _ => emit!(writer, "{}", name),
         }
     }
@@ -897,10 +897,10 @@ fn emit_array_use(
     match *size {
         ArraySize::Lit(value) => emit!(writer, "{}", value),
         ArraySize::Const(ref name) => {
-            emit!(writer, "(int) ");
+            emit!(writer, "(int)");
             emit_const_use(writer, context, name);
         }
-        ArraySize::Dynamic => emit!(writer, "(int) {}Len", name),
+        ArraySize::Dynamic => emit!(writer, "(int){}Len", name),
     }
 
     emit!(writer, ")");

--- a/src/csharp/mod.rs
+++ b/src/csharp/mod.rs
@@ -16,7 +16,7 @@ use std::fmt::{Display, Write};
 use std::mem;
 use unwrap::unwrap;
 
-const INDENT_WIDTH: usize = 2;
+const INDENT_WIDTH: usize = 4;
 
 pub struct LangCSharp {
     filter: HashSet<String>,
@@ -479,14 +479,14 @@ impl Lang for LangCSharp {
             emitln!(writer, "using System.Threading.Tasks;\n");
             emitln!(
                 writer,
-                "namespace {} {{",
+                "namespace {}\n{{",
                 self.context.functions_section.namespace
             );
             writer.indent();
 
             emitln!(
                 writer,
-                "internal partial class {} : I{} {{",
+                "internal partial class {} : I{}\n{{",
                 self.context.functions_section.class,
                 self.context.functions_section.class
             );
@@ -552,19 +552,19 @@ impl Lang for LangCSharp {
                 emitln!(writer, "using System.Threading.Tasks;\n");
                 emitln!(
                     writer,
-                    "namespace {} {{",
+                    "namespace {}\n{{",
                     self.context.interface_section.namespace
                 );
                 writer.indent();
 
                 emitln!(
                     writer,
-                    "public partial interface {} {{",
+                    "public partial interface {}\n{{",
                     self.context.interface_section.class
                 );
                 writer.indent();
 
-                for snippet in functions {
+                while let Some(snippet) = functions.next() {
                     if num_callbacks(&snippet.item.inputs) <= 1 {
                         emit_wrapper_function_decl(
                             &mut writer,
@@ -574,6 +574,10 @@ impl Lang for LangCSharp {
                             &snippet.item,
                         );
                         emitln!(writer, ";");
+                    }
+                    
+                    if functions.peek().is_some() {
+                        emitln!(writer, "");
                     }
                 }
 
@@ -599,7 +603,7 @@ impl Lang for LangCSharp {
 
             emitln!(
                 writer,
-                "namespace {} {{",
+                "namespace {}\n{{",
                 self.context.consts_section.namespace
             );
             writer.indent();
@@ -607,7 +611,7 @@ impl Lang for LangCSharp {
             emitln!(writer, "[PublicAPI]");
             emitln!(
                 writer,
-                "public static class {} {{",
+                "public static class {}\n{{",
                 self.context.consts_section.class
             );
             writer.indent();
@@ -646,7 +650,7 @@ impl Lang for LangCSharp {
 
             emitln!(
                 writer,
-                "namespace {} {{",
+                "namespace {}\n{{",
                 self.context.types_section.namespace
             );
             writer.indent();


### PR DESCRIPTION
**Changes:**
* Indentation changed to use 4 spaces from 2 spaces.
* Use opening bracket (`{`) in new line (namespaces, classes, structs, functions).
* Remove extra branckets `()` from return statement in `ToNative()` functions.
* Add new lines between method declaration in interfaces.
* Update Utilities namespace and BindingUtils class template.
* Remove extra space between cast type (ulong, int, UIntPtr) and variable.
* Update `csharp` code used in tests